### PR TITLE
library: add AnvilBaseChainID (31338) for two-anvil devnet

### DIFF
--- a/gosdk/library/chain_consts.go
+++ b/gosdk/library/chain_consts.go
@@ -48,6 +48,7 @@ const (
 
 	// testnets
 	AnvilChainID           = apptypes.ChainType(31337)    // Anvil Local
+	AnvilBaseChainID       = apptypes.ChainType(31338)    // Anvil Local (Base fork)
 	EthereumSepoliaChainID = apptypes.ChainType(11155111) // Ethereum Sepolia Testnet
 	PolygonMumbaiChainID   = apptypes.ChainType(80001)    // Polygon Mumbai Testnet
 	PolygonAmoyChainID     = apptypes.ChainType(80002)    // Polygon Amoy Testnet
@@ -76,6 +77,7 @@ func EVMChains() map[apptypes.ChainType]struct{} {
 		FantomChainID:           {},
 		BaseChainID:             {},
 		AnvilChainID:            {},
+		AnvilBaseChainID:        {},
 		EthereumSepoliaChainID:  {},
 		PolygonMumbaiChainID:    {},
 		PolygonAmoyChainID:      {},


### PR DESCRIPTION
## Summary
- Adds `AnvilBaseChainID = 31338` alongside existing `AnvilChainID = 31337`
- Registers it in `EVMChains()` so `IsEvmChain(31338)` returns true

## Why
`smart_example`'s `krishna/base-support` branch runs a two-anvil local devnet:
- `anvil` (chain 31337) forks Ethereum mainnet
- `anvil_base` (chain 31338) forks Base mainnet (\`--optimism\`)

Today `InitApp` rejects 31338 because `EVMChains()` doesn't include it, so appchain boots with `required_chains: [31337, 31338]` and crashes at startup:
\`\`\`
{"level":"fatal","error":"init app: chain ID 31338: unknown chain","message":"failed to start appnode"}
\`\`\`

Pure allowlist addition — no behavioural change for any existing chain.

## Test plan
- [x] \`go build ./gosdk/...\`
- [ ] Consume this commit in smart_example, rebuild appchain, verify \`make devnet-up-fresh\` completes handshake