### PR TITLE
gosdk: dispatch Midnight blocks to ExternalBlockProcessor

### DIFF
--- a/gosdk/state_transition.go
+++ b/gosdk/state_transition.go
@@ -179,6 +179,16 @@ func (b *DefaultBatchProcessor[appTx, R]) ProcessBatch(
 				extTxs = append(extTxs, ext...)
 			}
 
+		case library.IsMidnightChain(chainID):
+			// No receipt/log model — pass every block through; the app filters
+			// via MultichainStateAccessor.MidnightContractActions.
+			ext, err := b.extBlockProc.ProcessBlock(*blk, dbtx)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			extTxs = append(extTxs, ext...)
+
 		default:
 			logger.Error().Uint64("chainID", blk.ChainID).Msg("Unknown chain type")
 		}


### PR DESCRIPTION
## Summary
- `DefaultBatchProcessor.ProcessBatch` only had EVM and Solana branches; Midnight external blocks fell through to the default arm and logged `Unknown chain type`, so appchains never saw them.
- Add a `library.IsMidnightChain` branch that passes the block to the user-supplied `ExternalBlockProcessor`.

Midnight has no receipt/log model — there is nothing to filter on at the SDK boundary. The app is expected to query contract actions via `MultichainStateAccessor.MidnightContractActions` and decide which blocks are interesting.

Pairs with the core-side WS-subscription Midnight reader (core branch `midnight-writer`) which now emits `ConsensusUpdates` per Midnight block, populating `BlockVotes` for chain 800.

## Test plan
- [x] `go test ./gosdk/` — full SDK suite green
- [x] Example app rebuilds against patched SDK and consumes Midnight votes from a live Preprod indexer through pelacli without `Unknown chain type` errors